### PR TITLE
Fix: Ensure container listens on the correct port

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export PORT=${PORT:-8080}
+
 # Substitute environment variables in the nginx config template
 envsubst '${PORT}' < /etc/nginx/conf.d/default.template.conf > /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
The container was failing to start on Cloud Run because Nginx was not listening on the port specified by the `PORT` environment variable.

This was caused by the `PORT` variable not being explicitly exported in the `start.sh` script, which prevented `envsubst` from substituting it into the Nginx configuration.

This commit fixes the issue by adding `export PORT=${PORT:-8080}` to the `start.sh` script. This ensures that the `PORT` variable is available to `envsubst` and that Nginx is configured to listen on the correct port. The default value of 8080 is added for local testing convenience.