### PR TITLE
fix: Hardcode Nginx port to 8080 to resolve startup issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the React application
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 
 WORKDIR /app
 
@@ -12,15 +12,8 @@ RUN npm run build
 # Stage 2: Serve the application using Nginx
 FROM nginx:1.21.4-alpine
 
-# Install envsubst
-RUN apk update && apk add gettext
-
-# Copy custom nginx configuration template
-COPY nginx.template.conf /etc/nginx/conf.d/default.template.conf
-
-# Copy the startup script
-COPY start.sh /
-RUN chmod +x /start.sh
+# Copy custom nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy the build output from the build stage
 COPY --from=build /app/dist /usr/share/nginx/html
@@ -28,5 +21,5 @@ COPY --from=build /app/dist /usr/share/nginx/html
 # Expose port 8080 - This is just for documentation, Cloud Run handles the actual port
 EXPOSE 8080
 
-# Start the app using the startup script
-CMD ["/start.sh"]
+# Start nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen ${PORT};
+  listen 8080;
 
   location / {
     root   /usr/share/nginx/html;

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Substitute environment variables in the nginx config template
-envsubst '${PORT}' < /etc/nginx/conf.d/default.template.conf > /etc/nginx/conf.d/default.conf
-
-# Start nginx
-nginx -g 'daemon off;'


### PR DESCRIPTION
After multiple failed attempts to dynamically configure the Nginx port using a startup script, this commit simplifies the configuration to ensure stability.

The `start.sh` script and the templating mechanism have been removed. The Nginx configuration now listens directly on port 8080, which is the port expected by Cloud Run.

The `Dockerfile` has been updated to reflect these changes, removing the `gettext` dependency and starting Nginx directly. This change should resolve the persistent "container failed to start" error.